### PR TITLE
Fix: Restore layout on "Mes Créations" page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -169,7 +169,78 @@ nav {
     max-width: 1100px;
     margin: 0 auto;
 }
-/* Styles précédents... (je ne les remets pas pour la lisibilité, ils n'ont pas changé) */
+
+/* --- Grille des créations --- */
+.creations-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 30px;
+    margin-top: 2em;
+}
+
+/* Responsive pour la grille des créations */
+@media screen and (max-width: 992px) {
+    .creations-grid {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media screen and (max-width: 768px) {
+    .creations-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+/* --- Style des cartes de création --- */
+.creations-card {
+    background-color: var(--blanc);
+    border: 1px solid #E5E7EB;
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0,0,0,0.05);
+    overflow: hidden;
+    transition: transform 0.3s, box-shadow 0.3s;
+    display: flex;
+    flex-direction: column;
+}
+
+.creations-card:hover {
+    transform: translateY(-5px);
+    box-shadow: 0 10px 15px rgba(0,0,0,0.1);
+}
+
+.creations-card img {
+    width: 100%;
+    height: 200px;
+    object-fit: cover;
+}
+
+.creations-card h3 {
+    font-size: 1.25em;
+    margin: 15px;
+    color: var(--gris-fonce);
+}
+
+.creations-card p {
+    margin: 0 15px 15px;
+    flex-grow: 1; /* Pour que le footer de la carte reste en bas */
+}
+
+/* --- Style des tags de technologie --- */
+.tags {
+    padding: 15px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+}
+
+.tags span {
+    background-color: var(--bleu-sim32);
+    color: var(--blanc);
+    padding: 5px 12px;
+    border-radius: 20px;
+    font-size: 0.8em;
+    font-weight: 600;
+}
 
 
 /* --- MENU HAMBURGER RESPONSIVE (LA PARTIE IMPORTANTE) --- */


### PR DESCRIPTION
This commit fixes a layout regression on the "Mes Créations" page (creations.html).

The following issues have been addressed:
- The project cards in the "creations-grid" were stacking vertically. A responsive grid layout has been restored to display 3, 2, or 1 column depending on the screen width.
- The technology tags under each project were not styled. Their original styling as colored buttons has been restored.

The missing CSS rules for `.creations-grid`, `.creations-card`, and `.tags` have been added to `assets/css/style.css`.