### PR TITLE
feat: Adjust mobile menu for bottom alignment

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -273,11 +273,11 @@ nav {
         display: flex;
         flex-direction: column; /* On garde l'empilement vertical */
         align-items: center;
-        justify-content: flex-start; /* Aligne les items en haut */
+        justify-content: flex-end; /* Aligne les items en bas */
         width: 60%;
         transform: translateX(100%);
         transition: transform 0.5s ease-in;
-        padding: 5rem 0 0; /* Ajoute un padding en haut */
+        padding: 0 0 5rem; /* Ajoute un padding en bas */
         margin: 0;
     }
 


### PR DESCRIPTION
This commit adjusts the mobile menu's CSS to align the navigation links to the bottom of the slide-out panel.

- Changed `justify-content` from `flex-start` to `flex-end` in the `.nav-links` class for mobile view.
- Adjusted `padding` to apply at the bottom instead of the top, ensuring proper spacing.

These changes improve the ergonomics of the mobile menu without affecting the desktop layout.