### PR TITLE
Create a custom 404 error page

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Page non trouvée - SIM32</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="assets/css/style.css">
+</head>
+<body>
+    <div id="header-placeholder"></div>
+
+    <main class="error-container">
+        <div class="error-content">
+            <img src="assets/img/server_down.svg" alt="Illustration d'erreur" class="error-illustration">
+            <h1>Oops! Cette page est introuvable.</h1>
+            <p>La page que vous cherchez n'existe pas ou a été déplacée. Mais pas de panique, vous pouvez retrouver votre chemin.</p>
+            <a href="index.html" class="cta-button">Retour à l'accueil</a>
+        </div>
+    </main>
+
+    <div id="footer-placeholder"></div>
+
+    <script src="assets/js/app.js"></script>
+</body>
+</html>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -491,6 +491,32 @@ nav {
     }
 }
 
+/* --- Page 404 --- */
+.error-container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    text-align: center;
+    min-height: calc(100vh - 8vh - 8vh); /* Full height minus header and footer */
+    padding: 20px;
+}
+
+.error-content h1 {
+    font-size: 2.5em;
+    margin-bottom: 0.5em;
+}
+
+.error-content p {
+    font-size: 1.2em;
+    margin-bottom: 1.5em;
+    max-width: 600px;
+}
+
+.error-illustration {
+    max-width: 250px;
+    margin-bottom: 2em;
+}
+
 /* --- Contact Section --- */
 .contact-content {
     display: flex;


### PR DESCRIPTION
This commit introduces a custom 404 error page to improve user experience when a page is not found.

- Creates a new `404.html` file at the root of the project.
- The page includes the standard site header and footer for consistent navigation.
- The main content is centered and includes the `server_down.svg` illustration, a user-friendly title, a short explanation, and a button to return to the homepage.
- Adds necessary CSS styles to `assets/css/style.css` for a clean and responsive layout.