### PR TITLE
feat: Add legal pages and footer links

### DIFF
--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -1,3 +1,8 @@
-    <footer>
-        <p>&copy; 2025 SIM32 - Services Informatiques Miélan. Tous droits réservés.</p>
-        </footer>
+<footer>
+    <nav class="footer-links">
+        <a href="/mentions-legales.html">Mentions Légales</a> |
+        <a href="/cgv.html">CGV</a> |
+        <a href="/confidentialite.html">Politique de Confidentialité</a>
+    </nav>
+    <p>&copy; 2025 SIM32 - Services Informatiques Miélan. Tous droits réservés.</p>
+</footer>

--- a/cgv.html
+++ b/cgv.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Conditions Générales de Vente - SIM32</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="assets/css/style.css">
+
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/assets/favicon/favicon.svg" />
+    <link rel="shortcut icon" href="/assets/favicon/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png" />
+    <meta name="apple-mobile-web-app-title" content="SIM32" />
+    <link rel="manifest" href="/assets/favicon/site.webmanifest" />
+</head>
+<body>
+    <div id="header-placeholder"></div>
+
+    <main class="legal-page">
+        <section>
+            <h1>Conditions Générales de Vente (CGV)</h1>
+            <p><strong>Dernière mise à jour :</strong> [DATE DE MISE À JOUR]</p>
+
+            <h2>Article 1 : Objet</h2>
+            <p>Les présentes conditions régissent les ventes de services (maintenance informatique, création de site web, formation) par [INFORMATIONS DE L'ENTREPRISE].</p>
+
+            <h2>Article 2 : Prix</h2>
+            <p>Les prix de nos services sont indiqués en euros (€) et sont détaillés sur le devis fourni au client. Les prix sont fermes et non révisables pendant leur période de validité.</p>
+            <p>[DÉTAILS SUR LA TVA, EX: "TVA non applicable, art. 293 B du CGI"].</p>
+
+            <h2>Article 3 : Commandes et Devis</h2>
+            <p>Toute prestation fait l'objet d'un devis préalable, daté et signé par le client avec la mention "Bon pour accord". Le devis a une durée de validité de [DURÉE DE VALIDITÉ DU DEVIS, ex: 30 jours].</p>
+
+            <h2>Article 4 : Paiement</h2>
+            <p>Le règlement s'effectue selon les modalités précisées sur le devis ou la facture. Un acompte peut être demandé à la commande.</p>
+            <p>[MODALITÉS DE PAIEMENT À COMPLÉTER, ex: virement, chèque, etc.].</p>
+
+            <h2>Article 5 : Prestations de services</h2>
+
+            <h3>Section 5.1 : Pour les Particuliers</h3>
+            <p>Les services d'assistance et de formation sont réalisés à domicile ou à distance. Les délais d'intervention sont donnés à titre indicatif.</p>
+            <p>[AUTRES SPÉCIFICITÉS POUR LES PARTICULIERS À AJOUTER].</p>
+
+            <h3>Section 5.2 : Pour les Professionnels</h3>
+            <p>Les services de création de site web et de maintenance font l'objet d'un cahier des charges ou d'un contrat de maintenance spécifique. Les délais de livraison sont définis dans le devis.</p>
+            <p>[AUTRES SPÉCIFICITÉS POUR LES PROFESSIONNELS À AJOUTER, ex: garanties, maintenance, etc.].</p>
+
+            <h2>Article 6 : Droit de rétractation</h2>
+            <p>Conformément aux dispositions de l'article L.121-21 du Code de la Consommation, le client particulier dispose d'un délai de rétractation de 14 jours à compter de la conclusion du contrat pour les prestations de services.</p>
+
+            <h2>Article 7 : Responsabilité</h2>
+            <p>La responsabilité de [INFORMATIONS DE L'ENTREPRISE] ne saurait être engagée pour tous les inconvénients ou dommages inhérents à l'utilisation du réseau Internet.</p>
+
+            <h2>Article 8 : Droit applicable en cas de litiges</h2>
+            <p>La langue du présent contrat est la langue française. Les présentes conditions de vente sont soumises à la loi française.</p>
+
+        </section>
+    </main>
+
+    <div id="footer-placeholder"></div>
+<script src="assets/js/app.js"></script>
+</body>
+</html>

--- a/confidentialite.html
+++ b/confidentialite.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Politique de Confidentialité - SIM32</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="assets/css/style.css">
+
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/assets/favicon/favicon.svg" />
+    <link rel="shortcut icon" href="/assets/favicon/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png" />
+    <meta name="apple-mobile-web-app-title" content="SIM32" />
+    <link rel="manifest" href="/assets/favicon/site.webmanifest" />
+</head>
+<body>
+    <div id="header-placeholder"></div>
+
+    <main class="legal-page">
+        <section>
+            <h1>Politique de Confidentialité</h1>
+            <p><strong>Date d'entrée en vigueur :</strong> [DATE D'ENTRÉE EN VIGUEUR]</p>
+
+            <h2>1. Collecte de l'Information</h2>
+            <p>Nous collectons des informations lorsque vous nous contactez via le formulaire de contact ou directement par email. Les informations collectées incluent votre nom, votre adresse email, et votre numéro de téléphone.</p>
+            <p>Ces informations sont utilisées exclusivement pour répondre à votre demande de contact ou de devis.</p>
+
+            <h2>2. Utilisation des Données</h2>
+            <p>Les informations que nous recueillons auprès de vous peuvent être utilisées pour :</p>
+            <ul>
+                <li>Personnaliser votre expérience et répondre à vos besoins individuels</li>
+                <li>Fournir un contenu publicitaire personnalisé</li>
+                <li>Améliorer notre site</li>
+                <li>Vous contacter par e-mail ou téléphone</li>
+            </ul>
+
+            <h2>3. Confidentialité</h2>
+            <p>Nous sommes les seuls propriétaires des informations recueillies sur ce site. Vos informations personnelles ne seront pas vendues, échangées, transférées, ou données à une autre société pour n'importe quelle raison, sans votre consentement, en dehors de ce qui est nécessaire pour répondre à une demande ou une transaction.</p>
+
+            <h2>4. Divulgation à des Tiers</h2>
+            <p>Nous ne vendons, n'échangeons et ne transférons pas vos informations personnelles identifiables à des tiers. Cela ne comprend pas les tiers de confiance qui nous aident à exploiter notre site Web ou à mener nos affaires, tant que ces parties conviennent de garder ces informations confidentielles.</p>
+
+            <h2>5. Protection des Informations</h2>
+            <p>Nous mettons en œuvre une variété de mesures de sécurité pour préserver la sécurité de vos informations personnelles. Nous utilisons un cryptage à la pointe de la technologie pour protéger les informations sensibles transmises en ligne. Nous protégeons également vos informations hors ligne.</p>
+
+            <h2>6. Consentement</h2>
+            <p>En utilisant notre site, vous consentez à notre politique de confidentialité.</p>
+
+            <h2>7. Contact</h2>
+            <p>Pour toute question concernant cette politique de confidentialité, vous pouvez nous contacter aux coordonnées suivantes :</p>
+            <p>[INFORMATIONS DE L'ENTREPRISE]</p>
+
+        </section>
+    </main>
+
+    <div id="footer-placeholder"></div>
+<script src="assets/js/app.js"></script>
+</body>
+</html>

--- a/mentions-legales.html
+++ b/mentions-legales.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mentions Légales - SIM32</title>
+
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
+
+    <link rel="stylesheet" href="assets/css/style.css">
+
+    <link rel="icon" type="image/png" href="/assets/favicon/favicon-96x96.png" sizes="96x96" />
+    <link rel="icon" type="image/svg+xml" href="/assets/favicon/favicon.svg" />
+    <link rel="shortcut icon" href="/assets/favicon/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/assets/favicon/apple-touch-icon.png" />
+    <meta name="apple-mobile-web-app-title" content="SIM32" />
+    <link rel="manifest" href="/assets/favicon/site.webmanifest" />
+</head>
+<body>
+    <div id="header-placeholder"></div>
+
+    <main class="legal-page">
+        <section>
+            <h1>Mentions Légales</h1>
+
+            <h2>1. Éditeur du Site</h2>
+            <p>
+                <strong>Nom :</strong> Mathieu Bachmann (EI)<br>
+                <strong>Adresse :</strong> 6 Chemin De Rioumaou, 32160 Miélan<br>
+                <strong>Email :</strong> <a href="mailto:mathieu.bachmann@outlook.com">mathieu.bachmann@outlook.com</a><br>
+                <strong>Téléphone :</strong> 06 58 67 80 61
+            </p>
+
+            <h2>2. Immatriculation</h2>
+            <p>
+                <strong>Numéro SIREN :</strong> [NUMÉRO SIREN À VENIR]<br>
+                <strong>Numéro RCS :</strong> [NUMÉRO RCS À VENIR]
+            </p>
+
+            <h2>3. Hébergement</h2>
+            <p>
+                <strong>Hôte :</strong> O2SWITCH<br>
+                <strong>Type de société :</strong> SAS (société par actions simplifiée)<br>
+                <strong>Adresse :</strong> CHE DES PARDIAUX, 63000 CLERMONT FERRAND<br>
+                <strong>Téléphone :</strong> 04 44 44 60 40
+            </p>
+        </section>
+    </main>
+
+    <div id="footer-placeholder"></div>
+<script src="assets/js/app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
- Creates three new HTML files: `mentions-legales.html`, `cgv.html`, and `confidentialite.html`.
- Populates the pages with standard French legal text and placeholders for information to be added later.
- Each page is structured to include the site's standard header and footer using the existing JavaScript-based inclusion method.
- Updates the site footer in `_includes/_footer.html` to add navigation links to the newly created legal pages.