### PR TITLE
Feat: Adjust Homepage Hero Section Layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -103,7 +103,7 @@ nav {
     justify-content: center;
     align-items: center;
     text-align: center;
-    background-image: url('../img/active_support.svg');
+    background-image: url('../img/background-accueil.jpg');
     background-size: cover;
     background-position: center;
     background-repeat: no-repeat;
@@ -160,6 +160,14 @@ nav {
     background-color: #37B96D;
     border-color: #37B96D;
     transform: scale(1.05);
+}
+
+.illustration-container {
+    margin-top: 20px;
+}
+
+.illustration-container img {
+    max-height: 150px;
 }
 
 
@@ -403,18 +411,16 @@ nav {
     }
 }
 /* --- Trust Banner --- */
-.trust-banner-container {
-    background-color: var(--gris-clair); /* Same as other alternating sections */
+#trust-banner {
+    background-color: var(--gris-clair);
+    padding: 20px 0;
 }
 
-#trust-banner {
+#trust-banner .container {
     display: flex;
     align-items: center;
     justify-content: center;
     gap: 20px;
-    padding: 20px; /* Reduced padding for a more subtle look */
-    max-width: 1100px;
-    margin: 0 auto;
 }
 
 .trust-icon {
@@ -430,7 +436,7 @@ nav {
 }
 
 @media screen and (max-width: 768px) {
-    #trust-banner {
+    #trust-banner .container {
         flex-direction: column;
         text-align: center;
     }

--- a/index.html
+++ b/index.html
@@ -44,14 +44,17 @@
         </div>
     </div>
     <a href="#contact" class="cta-button">Me Contacter</a>
+    <div class="illustration-container">
+        <img src="assets/img/active_support.svg" alt="Illustration de support actif">
+    </div>
 </div>    
         </section>
-        <div class="trust-banner-container">
-            <section id="trust-banner">
+        <section id="trust-banner">
+            <div class="container">
                 <img src="assets/img/security_on.svg" alt="Icône de sécurité" class="trust-icon">
                 <p>Votre partenaire de confiance pour une technologie simple et sûre.</p>
-            </section>
-        </div>
+            </div>
+        </section>
 
         <section id="a-propos">
             <h2>Un double profil, pour un service unique</h2>


### PR DESCRIPTION
This commit implements several layout adjustments to the homepage hero section as requested.

- The original background image (`background-accueil.jpg`) has been restored to the `#accueil` section.
- The `active_support.svg` illustration has been moved from the background and placed as a centered `<img>` tag within the `#accueil` section.
- The `#trust-banner` section's content is now wrapped in a `.container` div, ensuring its width and centering are consistent with other sections on the page.
- The CSS has been updated to support these structural changes and maintain a responsive design.