### PR TITLE
feat: Improve Services Section and Fix Trust Banner Layout

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -412,11 +412,14 @@ nav {
 }
 /* --- Trust Banner --- */
 #trust-banner {
-    background-color: var(--gris-clair);
-    padding: 20px 0;
+    background-color: var(--blanc); /* Fond blanc pour la section */
+    padding: 60px 20px; /* Consistance avec les autres sections */
 }
 
 #trust-banner .container {
+    background-color: var(--gris-clair); /* Fond gris pour le contenu */
+    border-radius: 8px; /* Bords arrondis */
+    padding: 20px; /* Espacement interne */
     display: flex;
     align-items: center;
     justify-content: center;
@@ -498,6 +501,34 @@ nav {
     .a-propos-content {
         flex-direction: column;
     }
+}
+
+/* --- Responsive Service Cards for large screens --- */
+@media screen and (min-width: 769px) {
+  .service-card {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    align-items: center;
+    gap: 20px;
+    text-align: left;
+  }
+  .service-illustration {
+    grid-column: 1;
+    grid-row: 1;
+    margin-bottom: 0;
+  }
+  .service-title-group {
+    grid-column: 1;
+    grid-row: 2;
+    margin-bottom: 0;
+    justify-content: flex-start;
+  }
+  .service-card p {
+    grid-column: 2;
+    grid-row: 1 / 3;
+    margin: 0;
+    align-self: center;
+  }
 }
 
 /* --- Footer --- */


### PR DESCRIPTION
This commit introduces two layout improvements to the homepage:

1.  **Fix Trust Banner Layout:**
    - The grey background of the #trust-banner is now applied only to the width-limited content container, not the full-width section.
    - The section background is now white, consistent with the rest of the page body.

2.  **Improve "Services" Card Layout:**
    - On large screens (min-width: 769px), the .service-card now uses a two-column grid layout.
    - The left column contains the service illustration and title.
    - The right column contains the service description paragraph.
    - The mobile layout remains unchanged.