### PR TITLE
Integrate Tarteaucitron for cookie consent management (v2 - Step 1).

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,61 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+    <script src="/tarteaucitron/tarteaucitron.min.js"></script>
+
+<script type="text/javascript">
+tarteaucitron.init({
+  "privacyUrl": "/confidentialite.html", /* Url de la politique de confidentialité */
+  "bodyPosition": "top",
+
+  "hashtag": "#tarteaucitron",
+  "cookieName": "tarteaucitron",
+
+  "orientation": "middle",
+
+  "groupServices": true,
+  "showDetailsOnClick": true,
+  "serviceDefaultState": "wait",
+
+  "showAlertSmall": false,
+  "cookieslist": false,
+  "cookieslistEmbed": false,
+
+  "closePopup": true,
+
+  "showIcon": true,
+  "iconPosition": "BottomRight",
+
+  "adblocker": false,
+
+  "DenyAllCta" : true,
+  "AcceptAllCta" : true,
+  "highPrivacy": true,
+  "alwaysNeedConsent": false,
+
+  "handleBrowserDNTRequest": false,
+
+  "removeCredit": false,
+  "moreInfoLink": true,
+
+  "useExternalCss": false,
+  "useExternalJs": false,
+
+  "readmoreLink": "",
+
+  "mandatory": true,
+  "mandatoryCta": false,
+
+  "googleConsentMode": true,
+  "bingConsentMode": true,
+  "softConsentMode": false,
+
+  "dataLayer": false,
+  "serverSide": false,
+
+  "partnersList": true
+});
+</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Erreur 404 - Page non trouvée | SIM32</title>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -523,6 +523,87 @@ nav {
     }
 }
 
+/* --- Tarteaucitron Custom Styles --- */
+
+/* Main banner */
+#tarteaucitronRoot #tarteaucitronAlert,
+#tarteaucitronRoot #tarteaucitronAlertBig {
+    background-color: var(--gris-fonce) !important;
+    color: var(--blanc) !important;
+}
+
+#tarteaucitronRoot #tarteaucitronAlert #tarteaucitronDisclaimerAlert {
+    color: var(--blanc) !important;
+}
+
+/* Common style for buttons */
+#tarteaucitronRoot .tarteaucitronButton {
+    border-radius: 50px !important;
+    padding: 10px 24px !important;
+    font-weight: 700 !important;
+    transition: transform 0.2s, background-color 0.2s !important;
+    border: none !important;
+    cursor: pointer;
+}
+
+#tarteaucitronRoot .tarteaucitronButton:hover {
+    transform: scale(1.05) !important;
+}
+
+/* "Accept all" button */
+#tarteaucitronRoot #tarteaucitronAll {
+    background-color: var(--vert-sim32) !important;
+    color: var(--gris-fonce) !important;
+}
+
+#tarteaucitronRoot #tarteaucitronAll:hover {
+    background-color: #37B96D !important;
+}
+
+/* "Deny all" button */
+#tarteaucitronRoot #tarteaucitronDeny {
+    background-color: #6B7280 !important; /* Medium gray */
+    color: var(--blanc) !important;
+}
+
+#tarteaucitronRoot #tarteaucitronDeny:hover {
+    background-color: #4B5563 !important; /* Darker gray */
+}
+
+/* "Personalize" button */
+#tarteaucitronRoot #tarteaucitronClosePanel {
+    background-color: transparent !important;
+    color: var(--blanc) !important;
+    text-decoration: underline !important;
+    font-weight: normal !important;
+    padding: 10px !important;
+}
+
+/* --- Panel Styles --- */
+#tarteaucitronRoot #tarteaucitronPanel {
+    background: var(--blanc) !important;
+    color: var(--gris-fonce) !important;
+}
+
+#tarteaucitronRoot #tarteaucitronPanel #tarteaucitronPanelHeader h2 {
+    color: var(--bleu-sim32) !important;
+    font-size: 1.5em !important;
+}
+
+#tarteaucitronRoot #tarteaucitronPanel .tarteaucitronLine .tarteaucitronName {
+    font-weight: 600 !important;
+}
+
+#tarteaucitronRoot #tarteaucitronPanel .tarteaucitronH3 {
+    color: var(--bleu-sim32) !important;
+}
+
+/* --- Little Icon --- */
+#tarteaucitronRoot #tarteaucitronIcon {
+    background-color: var(--bleu-sim32) !important;
+    border-radius: 50% !important;
+}
+
 /* --- Legal Pages --- */
 .legal-page h1,
 .legal-page h2,

--- a/cgu.html
+++ b/cgu.html
@@ -1,6 +1,61 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+    <script src="/tarteaucitron/tarteaucitron.min.js"></script>
+
+<script type="text/javascript">
+tarteaucitron.init({
+  "privacyUrl": "/confidentialite.html", /* Url de la politique de confidentialité */
+  "bodyPosition": "top",
+
+  "hashtag": "#tarteaucitron",
+  "cookieName": "tarteaucitron",
+
+  "orientation": "middle",
+
+  "groupServices": true,
+  "showDetailsOnClick": true,
+  "serviceDefaultState": "wait",
+
+  "showAlertSmall": false,
+  "cookieslist": false,
+  "cookieslistEmbed": false,
+
+  "closePopup": true,
+
+  "showIcon": true,
+  "iconPosition": "BottomRight",
+
+  "adblocker": false,
+
+  "DenyAllCta" : true,
+  "AcceptAllCta" : true,
+  "highPrivacy": true,
+  "alwaysNeedConsent": false,
+
+  "handleBrowserDNTRequest": false,
+
+  "removeCredit": false,
+  "moreInfoLink": true,
+
+  "useExternalCss": false,
+  "useExternalJs": false,
+
+  "readmoreLink": "",
+
+  "mandatory": true,
+  "mandatoryCta": false,
+
+  "googleConsentMode": true,
+  "bingConsentMode": true,
+  "softConsentMode": false,
+
+  "dataLayer": false,
+  "serverSide": false,
+
+  "partnersList": true
+});
+</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Conditions Générales d'Utilisation - SIM32 (Miélan, Gers)</title>

--- a/cgv.html
+++ b/cgv.html
@@ -1,6 +1,61 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+    <script src="/tarteaucitron/tarteaucitron.min.js"></script>
+
+<script type="text/javascript">
+tarteaucitron.init({
+  "privacyUrl": "/confidentialite.html", /* Url de la politique de confidentialité */
+  "bodyPosition": "top",
+
+  "hashtag": "#tarteaucitron",
+  "cookieName": "tarteaucitron",
+
+  "orientation": "middle",
+
+  "groupServices": true,
+  "showDetailsOnClick": true,
+  "serviceDefaultState": "wait",
+
+  "showAlertSmall": false,
+  "cookieslist": false,
+  "cookieslistEmbed": false,
+
+  "closePopup": true,
+
+  "showIcon": true,
+  "iconPosition": "BottomRight",
+
+  "adblocker": false,
+
+  "DenyAllCta" : true,
+  "AcceptAllCta" : true,
+  "highPrivacy": true,
+  "alwaysNeedConsent": false,
+
+  "handleBrowserDNTRequest": false,
+
+  "removeCredit": false,
+  "moreInfoLink": true,
+
+  "useExternalCss": false,
+  "useExternalJs": false,
+
+  "readmoreLink": "",
+
+  "mandatory": true,
+  "mandatoryCta": false,
+
+  "googleConsentMode": true,
+  "bingConsentMode": true,
+  "softConsentMode": false,
+
+  "dataLayer": false,
+  "serverSide": false,
+
+  "partnersList": true
+});
+</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Conditions Générales de Vente - SIM32 (Miélan, Gers)</title>

--- a/confidentialite.html
+++ b/confidentialite.html
@@ -1,6 +1,61 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+    <script src="/tarteaucitron/tarteaucitron.min.js"></script>
+
+<script type="text/javascript">
+tarteaucitron.init({
+  "privacyUrl": "/confidentialite.html", /* Url de la politique de confidentialité */
+  "bodyPosition": "top",
+
+  "hashtag": "#tarteaucitron",
+  "cookieName": "tarteaucitron",
+
+  "orientation": "middle",
+
+  "groupServices": true,
+  "showDetailsOnClick": true,
+  "serviceDefaultState": "wait",
+
+  "showAlertSmall": false,
+  "cookieslist": false,
+  "cookieslistEmbed": false,
+
+  "closePopup": true,
+
+  "showIcon": true,
+  "iconPosition": "BottomRight",
+
+  "adblocker": false,
+
+  "DenyAllCta" : true,
+  "AcceptAllCta" : true,
+  "highPrivacy": true,
+  "alwaysNeedConsent": false,
+
+  "handleBrowserDNTRequest": false,
+
+  "removeCredit": false,
+  "moreInfoLink": true,
+
+  "useExternalCss": false,
+  "useExternalJs": false,
+
+  "readmoreLink": "",
+
+  "mandatory": true,
+  "mandatoryCta": false,
+
+  "googleConsentMode": true,
+  "bingConsentMode": true,
+  "softConsentMode": false,
+
+  "dataLayer": false,
+  "serverSide": false,
+
+  "partnersList": true
+});
+</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Politique de Confidentialité - SIM32 (Miélan, Gers)</title>

--- a/creations.html
+++ b/creations.html
@@ -1,6 +1,61 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+    <script src="/tarteaucitron/tarteaucitron.min.js"></script>
+
+<script type="text/javascript">
+tarteaucitron.init({
+  "privacyUrl": "/confidentialite.html", /* Url de la politique de confidentialité */
+  "bodyPosition": "top",
+
+  "hashtag": "#tarteaucitron",
+  "cookieName": "tarteaucitron",
+
+  "orientation": "middle",
+
+  "groupServices": true,
+  "showDetailsOnClick": true,
+  "serviceDefaultState": "wait",
+
+  "showAlertSmall": false,
+  "cookieslist": false,
+  "cookieslistEmbed": false,
+
+  "closePopup": true,
+
+  "showIcon": true,
+  "iconPosition": "BottomRight",
+
+  "adblocker": false,
+
+  "DenyAllCta" : true,
+  "AcceptAllCta" : true,
+  "highPrivacy": true,
+  "alwaysNeedConsent": false,
+
+  "handleBrowserDNTRequest": false,
+
+  "removeCredit": false,
+  "moreInfoLink": true,
+
+  "useExternalCss": false,
+  "useExternalJs": false,
+
+  "readmoreLink": "",
+
+  "mandatory": true,
+  "mandatoryCta": false,
+
+  "googleConsentMode": true,
+  "bingConsentMode": true,
+  "softConsentMode": false,
+
+  "dataLayer": false,
+  "serverSide": false,
+
+  "partnersList": true
+});
+</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mes Créations - Projets Web et Informatiques | SIM32</title>

--- a/easter-egg.html
+++ b/easter-egg.html
@@ -1,6 +1,61 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+    <script src="/tarteaucitron/tarteaucitron.min.js"></script>
+
+<script type="text/javascript">
+tarteaucitron.init({
+  "privacyUrl": "/confidentialite.html", /* Url de la politique de confidentialité */
+  "bodyPosition": "top",
+
+  "hashtag": "#tarteaucitron",
+  "cookieName": "tarteaucitron",
+
+  "orientation": "middle",
+
+  "groupServices": true,
+  "showDetailsOnClick": true,
+  "serviceDefaultState": "wait",
+
+  "showAlertSmall": false,
+  "cookieslist": false,
+  "cookieslistEmbed": false,
+
+  "closePopup": true,
+
+  "showIcon": true,
+  "iconPosition": "BottomRight",
+
+  "adblocker": false,
+
+  "DenyAllCta" : true,
+  "AcceptAllCta" : true,
+  "highPrivacy": true,
+  "alwaysNeedConsent": false,
+
+  "handleBrowserDNTRequest": false,
+
+  "removeCredit": false,
+  "moreInfoLink": true,
+
+  "useExternalCss": false,
+  "useExternalJs": false,
+
+  "readmoreLink": "",
+
+  "mandatory": true,
+  "mandatoryCta": false,
+
+  "googleConsentMode": true,
+  "bingConsentMode": true,
+  "softConsentMode": false,
+
+  "dataLayer": false,
+  "serverSide": false,
+
+  "partnersList": true
+});
+</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Easter Egg</title>

--- a/formulaire-retractation.html
+++ b/formulaire-retractation.html
@@ -1,6 +1,61 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+    <script src="/tarteaucitron/tarteaucitron.min.js"></script>
+
+<script type="text/javascript">
+tarteaucitron.init({
+  "privacyUrl": "/confidentialite.html", /* Url de la politique de confidentialité */
+  "bodyPosition": "top",
+
+  "hashtag": "#tarteaucitron",
+  "cookieName": "tarteaucitron",
+
+  "orientation": "middle",
+
+  "groupServices": true,
+  "showDetailsOnClick": true,
+  "serviceDefaultState": "wait",
+
+  "showAlertSmall": false,
+  "cookieslist": false,
+  "cookieslistEmbed": false,
+
+  "closePopup": true,
+
+  "showIcon": true,
+  "iconPosition": "BottomRight",
+
+  "adblocker": false,
+
+  "DenyAllCta" : true,
+  "AcceptAllCta" : true,
+  "highPrivacy": true,
+  "alwaysNeedConsent": false,
+
+  "handleBrowserDNTRequest": false,
+
+  "removeCredit": false,
+  "moreInfoLink": true,
+
+  "useExternalCss": false,
+  "useExternalJs": false,
+
+  "readmoreLink": "",
+
+  "mandatory": true,
+  "mandatoryCta": false,
+
+  "googleConsentMode": true,
+  "bingConsentMode": true,
+  "softConsentMode": false,
+
+  "dataLayer": false,
+  "serverSide": false,
+
+  "partnersList": true
+});
+</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Formulaire de Rétractation - SIM32</title>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,61 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+    <script src="/tarteaucitron/tarteaucitron.min.js"></script>
+
+<script type="text/javascript">
+tarteaucitron.init({
+  "privacyUrl": "/confidentialite.html", /* Url de la politique de confidentialité */
+  "bodyPosition": "top",
+
+  "hashtag": "#tarteaucitron",
+  "cookieName": "tarteaucitron",
+
+  "orientation": "middle",
+
+  "groupServices": true,
+  "showDetailsOnClick": true,
+  "serviceDefaultState": "wait",
+
+  "showAlertSmall": false,
+  "cookieslist": false,
+  "cookieslistEmbed": false,
+
+  "closePopup": true,
+
+  "showIcon": true,
+  "iconPosition": "BottomRight",
+
+  "adblocker": false,
+
+  "DenyAllCta" : true,
+  "AcceptAllCta" : true,
+  "highPrivacy": true,
+  "alwaysNeedConsent": false,
+
+  "handleBrowserDNTRequest": false,
+
+  "removeCredit": false,
+  "moreInfoLink": true,
+
+  "useExternalCss": false,
+  "useExternalJs": false,
+
+  "readmoreLink": "",
+
+  "mandatory": true,
+  "mandatoryCta": false,
+
+  "googleConsentMode": true,
+  "bingConsentMode": true,
+  "softConsentMode": false,
+
+  "dataLayer": false,
+  "serverSide": false,
+
+  "partnersList": true
+});
+</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>SIM32 - Dépannage Informatique et Création de Site Web à Miélan (Gers)</title>

--- a/mentions-legales.html
+++ b/mentions-legales.html
@@ -1,6 +1,61 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+    <script src="/tarteaucitron/tarteaucitron.min.js"></script>
+
+<script type="text/javascript">
+tarteaucitron.init({
+  "privacyUrl": "/confidentialite.html", /* Url de la politique de confidentialité */
+  "bodyPosition": "top",
+
+  "hashtag": "#tarteaucitron",
+  "cookieName": "tarteaucitron",
+
+  "orientation": "middle",
+
+  "groupServices": true,
+  "showDetailsOnClick": true,
+  "serviceDefaultState": "wait",
+
+  "showAlertSmall": false,
+  "cookieslist": false,
+  "cookieslistEmbed": false,
+
+  "closePopup": true,
+
+  "showIcon": true,
+  "iconPosition": "BottomRight",
+
+  "adblocker": false,
+
+  "DenyAllCta" : true,
+  "AcceptAllCta" : true,
+  "highPrivacy": true,
+  "alwaysNeedConsent": false,
+
+  "handleBrowserDNTRequest": false,
+
+  "removeCredit": false,
+  "moreInfoLink": true,
+
+  "useExternalCss": false,
+  "useExternalJs": false,
+
+  "readmoreLink": "",
+
+  "mandatory": true,
+  "mandatoryCta": false,
+
+  "googleConsentMode": true,
+  "bingConsentMode": true,
+  "softConsentMode": false,
+
+  "dataLayer": false,
+  "serverSide": false,
+
+  "partnersList": true
+});
+</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Mentions Légales - SIM32 (Miélan, Gers)</title>

--- a/questionnaire.html
+++ b/questionnaire.html
@@ -1,6 +1,61 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+    <script src="/tarteaucitron/tarteaucitron.min.js"></script>
+
+<script type="text/javascript">
+tarteaucitron.init({
+  "privacyUrl": "/confidentialite.html", /* Url de la politique de confidentialité */
+  "bodyPosition": "top",
+
+  "hashtag": "#tarteaucitron",
+  "cookieName": "tarteaucitron",
+
+  "orientation": "middle",
+
+  "groupServices": true,
+  "showDetailsOnClick": true,
+  "serviceDefaultState": "wait",
+
+  "showAlertSmall": false,
+  "cookieslist": false,
+  "cookieslistEmbed": false,
+
+  "closePopup": true,
+
+  "showIcon": true,
+  "iconPosition": "BottomRight",
+
+  "adblocker": false,
+
+  "DenyAllCta" : true,
+  "AcceptAllCta" : true,
+  "highPrivacy": true,
+  "alwaysNeedConsent": false,
+
+  "handleBrowserDNTRequest": false,
+
+  "removeCredit": false,
+  "moreInfoLink": true,
+
+  "useExternalCss": false,
+  "useExternalJs": false,
+
+  "readmoreLink": "",
+
+  "mandatory": true,
+  "mandatoryCta": false,
+
+  "googleConsentMode": true,
+  "bingConsentMode": true,
+  "softConsentMode": false,
+
+  "dataLayer": false,
+  "serverSide": false,
+
+  "partnersList": true
+});
+</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Questionnaire Projet Web - SIM32</title>

--- a/tarifs.html
+++ b/tarifs.html
@@ -1,6 +1,61 @@
 <!DOCTYPE html>
 <html lang="fr">
 <head>
+    <script src="/tarteaucitron/tarteaucitron.min.js"></script>
+
+<script type="text/javascript">
+tarteaucitron.init({
+  "privacyUrl": "/confidentialite.html", /* Url de la politique de confidentialité */
+  "bodyPosition": "top",
+
+  "hashtag": "#tarteaucitron",
+  "cookieName": "tarteaucitron",
+
+  "orientation": "middle",
+
+  "groupServices": true,
+  "showDetailsOnClick": true,
+  "serviceDefaultState": "wait",
+
+  "showAlertSmall": false,
+  "cookieslist": false,
+  "cookieslistEmbed": false,
+
+  "closePopup": true,
+
+  "showIcon": true,
+  "iconPosition": "BottomRight",
+
+  "adblocker": false,
+
+  "DenyAllCta" : true,
+  "AcceptAllCta" : true,
+  "highPrivacy": true,
+  "alwaysNeedConsent": false,
+
+  "handleBrowserDNTRequest": false,
+
+  "removeCredit": false,
+  "moreInfoLink": true,
+
+  "useExternalCss": false,
+  "useExternalJs": false,
+
+  "readmoreLink": "",
+
+  "mandatory": true,
+  "mandatoryCta": false,
+
+  "googleConsentMode": true,
+  "bingConsentMode": true,
+  "softConsentMode": false,
+
+  "dataLayer": false,
+  "serverSide": false,
+
+  "partnersList": true
+});
+</script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Tarifs Dépannage Informatique & Création Web - SIM32 (Miélan, Gers)</title>


### PR DESCRIPTION
This commit introduces the Tarteaucitron cookie consent manager to the website.

- The Tarteaucitron initialization script has been added to the `<head>` of all HTML pages to ensure it loads on every page.
- Custom CSS has been added to `assets/css/style.css` to override the default Tarteaucitron styles. The new styles align the cookie banner, buttons, and management panel with the website's existing visual identity, using the established CSS color variables.