### PR TITLE
Fix: Update logo path after rename

### DIFF
--- a/_includes/_header.html
+++ b/_includes/_header.html
@@ -1,7 +1,7 @@
 <header>
 <nav>
     <a href="index.html" class="logo">
-        <img src="assets/img/Logo SIM32.png" alt="Logo SIM32">
+        <img src="assets/img/Logo-SIM32.png" alt="Logo SIM32">
         <span>SIM32</span>
     </a>
     <ul class="nav-links"> <li><a href="index.html#a-propos">À Propos</a></li>


### PR DESCRIPTION
Updated the logo path in the header include file to reflect the renaming of the logo image from 'Logo SIM32.png' to 'Logo-SIM32.png'.

This change ensures the logo is displayed correctly across the site.