### PR TITLE
feat: Add HubSpot tracking script to all HTML pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -95,6 +95,9 @@ tarteaucitron.user.clarityId = 'tkcqmxyhgp';
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "tkcqmxyhgp");
 </script>
+<!-- Start of HubSpot Embed Code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/146922861.js"></script>
+<!-- End of HubSpot Embed Code -->
 </head>
 <body>
     <div id="header-placeholder"></div>

--- a/cgu.html
+++ b/cgu.html
@@ -98,6 +98,9 @@ tarteaucitron.user.clarityId = 'tkcqmxyhgp';
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "tkcqmxyhgp");
 </script>
+<!-- Start of HubSpot Embed Code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/146922861.js"></script>
+<!-- End of HubSpot Embed Code -->
 </head>
 <body class="legal-page">
     <div id="header-placeholder"></div>

--- a/cgv.html
+++ b/cgv.html
@@ -98,6 +98,9 @@ tarteaucitron.user.clarityId = 'tkcqmxyhgp';
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "tkcqmxyhgp");
 </script>
+<!-- Start of HubSpot Embed Code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/146922861.js"></script>
+<!-- End of HubSpot Embed Code -->
 </head>
 <body class="legal-page">
     <div id="header-placeholder"></div>

--- a/confidentialite.html
+++ b/confidentialite.html
@@ -98,6 +98,9 @@ tarteaucitron.user.clarityId = 'tkcqmxyhgp';
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "tkcqmxyhgp");
 </script>
+<!-- Start of HubSpot Embed Code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/146922861.js"></script>
+<!-- End of HubSpot Embed Code -->
 </head>
 <body class="legal-page">
     <div id="header-placeholder"></div>

--- a/creations.html
+++ b/creations.html
@@ -97,6 +97,9 @@ tarteaucitron.user.clarityId = 'tkcqmxyhgp';
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "tkcqmxyhgp");
 </script>
+<!-- Start of HubSpot Embed Code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/146922861.js"></script>
+<!-- End of HubSpot Embed Code -->
 </head>
 <body>
     <div id="header-placeholder"></div>

--- a/easter-egg.html
+++ b/easter-egg.html
@@ -91,6 +91,9 @@ tarteaucitron.user.clarityId = 'tkcqmxyhgp';
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "tkcqmxyhgp");
 </script>
+<!-- Start of HubSpot Embed Code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/146922861.js"></script>
+<!-- End of HubSpot Embed Code -->
 </head>
 <body>
     <div class="easter-egg-container">

--- a/formulaire-retractation.html
+++ b/formulaire-retractation.html
@@ -109,6 +109,9 @@ tarteaucitron.user.clarityId = 'tkcqmxyhgp';
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "tkcqmxyhgp");
 </script>
+<!-- Start of HubSpot Embed Code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/146922861.js"></script>
+<!-- End of HubSpot Embed Code -->
 </head>
 <body class="legal-page">
     <div id="header-placeholder"></div>

--- a/index.html
+++ b/index.html
@@ -97,6 +97,9 @@ tarteaucitron.user.clarityId = 'tkcqmxyhgp';
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "tkcqmxyhgp");
 </script>
+<!-- Start of HubSpot Embed Code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/146922861.js"></script>
+<!-- End of HubSpot Embed Code -->
 </head>
 <body>
     <div id="header-placeholder"></div>

--- a/mentions-legales.html
+++ b/mentions-legales.html
@@ -98,6 +98,9 @@ tarteaucitron.user.clarityId = 'tkcqmxyhgp';
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "tkcqmxyhgp");
 </script>
+<!-- Start of HubSpot Embed Code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/146922861.js"></script>
+<!-- End of HubSpot Embed Code -->
 </head>
 <body class="legal-page">
     <div id="header-placeholder"></div>

--- a/questionnaire.html
+++ b/questionnaire.html
@@ -97,6 +97,9 @@ tarteaucitron.user.clarityId = 'tkcqmxyhgp';
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "tkcqmxyhgp");
 </script>
+<!-- Start of HubSpot Embed Code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/146922861.js"></script>
+<!-- End of HubSpot Embed Code -->
 </head>
 <body>
     <div id="header-placeholder"></div>

--- a/tarifs.html
+++ b/tarifs.html
@@ -97,6 +97,9 @@ tarteaucitron.user.clarityId = 'tkcqmxyhgp';
         y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
     })(window, document, "clarity", "script", "tkcqmxyhgp");
 </script>
+<!-- Start of HubSpot Embed Code -->
+<script type="text/javascript" id="hs-script-loader" async defer src="//js.hs-scripts.com/146922861.js"></script>
+<!-- End of HubSpot Embed Code -->
 </head>
 <body>
     <div id="promo-banner" class="sticky-banner">


### PR DESCRIPTION
Adds the HubSpot tracking script to the <head> of all HTML pages to allow for HubSpot's verification bot to validate the site.

This is necessary for the HubSpot integration to be fully functional.