### PR TITLE
fix(consent): add gcmanalyticsstorage to Tarteaucitron

### DIFF
--- a/404.html
+++ b/404.html
@@ -56,6 +56,8 @@ tarteaucitron.init({
   "partnersList": true
 });
 
+(tarteaucitron.job = tarteaucitron.job || []).push('gcmanalyticsstorage');
+
 // Google Tag Manager
 tarteaucitron.user.googletagmanagerId = 'GTM-NHCGHJW5';
 (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');

--- a/cgu.html
+++ b/cgu.html
@@ -56,6 +56,8 @@ tarteaucitron.init({
   "partnersList": true
 });
 
+(tarteaucitron.job = tarteaucitron.job || []).push('gcmanalyticsstorage');
+
 // Google Tag Manager
 tarteaucitron.user.googletagmanagerId = 'GTM-NHCGHJW5';
 (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');

--- a/cgv.html
+++ b/cgv.html
@@ -56,6 +56,8 @@ tarteaucitron.init({
   "partnersList": true
 });
 
+(tarteaucitron.job = tarteaucitron.job || []).push('gcmanalyticsstorage');
+
 // Google Tag Manager
 tarteaucitron.user.googletagmanagerId = 'GTM-NHCGHJW5';
 (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');

--- a/confidentialite.html
+++ b/confidentialite.html
@@ -56,6 +56,8 @@ tarteaucitron.init({
   "partnersList": true
 });
 
+(tarteaucitron.job = tarteaucitron.job || []).push('gcmanalyticsstorage');
+
 // Google Tag Manager
 tarteaucitron.user.googletagmanagerId = 'GTM-NHCGHJW5';
 (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');

--- a/creations.html
+++ b/creations.html
@@ -56,6 +56,8 @@ tarteaucitron.init({
   "partnersList": true
 });
 
+(tarteaucitron.job = tarteaucitron.job || []).push('gcmanalyticsstorage');
+
 // Google Tag Manager
 tarteaucitron.user.googletagmanagerId = 'GTM-NHCGHJW5';
 (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');

--- a/easter-egg.html
+++ b/easter-egg.html
@@ -56,6 +56,8 @@ tarteaucitron.init({
   "partnersList": true
 });
 
+(tarteaucitron.job = tarteaucitron.job || []).push('gcmanalyticsstorage');
+
 // Google Tag Manager
 tarteaucitron.user.googletagmanagerId = 'GTM-NHCGHJW5';
 (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');

--- a/formulaire-retractation.html
+++ b/formulaire-retractation.html
@@ -56,6 +56,8 @@ tarteaucitron.init({
   "partnersList": true
 });
 
+(tarteaucitron.job = tarteaucitron.job || []).push('gcmanalyticsstorage');
+
 // Google Tag Manager
 tarteaucitron.user.googletagmanagerId = 'GTM-NHCGHJW5';
 (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');

--- a/index.html
+++ b/index.html
@@ -56,6 +56,8 @@ tarteaucitron.init({
   "partnersList": true
 });
 
+(tarteaucitron.job = tarteaucitron.job || []).push('gcmanalyticsstorage');
+
 // Google Tag Manager
 tarteaucitron.user.googletagmanagerId = 'GTM-NHCGHJW5';
 (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');

--- a/mentions-legales.html
+++ b/mentions-legales.html
@@ -56,6 +56,8 @@ tarteaucitron.init({
   "partnersList": true
 });
 
+(tarteaucitron.job = tarteaucitron.job || []).push('gcmanalyticsstorage');
+
 // Google Tag Manager
 tarteaucitron.user.googletagmanagerId = 'GTM-NHCGHJW5';
 (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');

--- a/questionnaire.html
+++ b/questionnaire.html
@@ -56,6 +56,8 @@ tarteaucitron.init({
   "partnersList": true
 });
 
+(tarteaucitron.job = tarteaucitron.job || []).push('gcmanalyticsstorage');
+
 // Google Tag Manager
 tarteaucitron.user.googletagmanagerId = 'GTM-NHCGHJW5';
 (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');

--- a/tarifs.html
+++ b/tarifs.html
@@ -56,6 +56,8 @@ tarteaucitron.init({
   "partnersList": true
 });
 
+(tarteaucitron.job = tarteaucitron.job || []).push('gcmanalyticsstorage');
+
 // Google Tag Manager
 tarteaucitron.user.googletagmanagerId = 'GTM-NHCGHJW5';
 (tarteaucitron.job = tarteaucitron.job || []).push('googletagmanager');


### PR DESCRIPTION
This change adds the 'gcmanalyticsstorage' job to the Tarteaucitron configuration on all HTML pages.

This is necessary to correctly transmit the user's consent status to Google and resolve the "0% consent rate" issue in Google Analytics.

The script is inserted immediately after the tarteaucitron.init() call, as per the Google Consent Mode v2 implementation guidelines for Tarteaucitron.